### PR TITLE
[Fix] 펀딩 상태 별 리스트 출력 오류 수정

### DIFF
--- a/src/main/java/com/likelion/demoday/config/SecurityConfig.java
+++ b/src/main/java/com/likelion/demoday/config/SecurityConfig.java
@@ -28,6 +28,8 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        System.out.println(">>> SecurityConfig loaded. jwtAuthenticationFilter=" + jwtAuthenticationFilter.getClass());
+
         http
                 .csrf(csrf -> csrf.disable())
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
@@ -36,6 +38,9 @@ public class SecurityConfig {
                 .formLogin(form -> form.disable())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth
+                        // 유저는 로그인 필요
+                        .requestMatchers(HttpMethod.GET, "/api/v1/fundings/my").authenticated()
+
                         // 게스트 허용
                         .requestMatchers(HttpMethod.GET,  "/api/v1/fundings/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/fundings/*/contributions").permitAll()

--- a/src/main/java/com/likelion/demoday/controller/FundingController.java
+++ b/src/main/java/com/likelion/demoday/controller/FundingController.java
@@ -5,6 +5,8 @@ import com.likelion.demoday.dto.request.CreateFundingRequest;
 import com.likelion.demoday.dto.request.StopFundingRequest;
 import com.likelion.demoday.dto.response.FundingDetailResponse;
 import com.likelion.demoday.dto.response.FundingListResponse;
+import com.likelion.demoday.global.exception.BusinessException;
+import com.likelion.demoday.global.exception.ErrorCode;
 import com.likelion.demoday.service.FundingService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -43,12 +45,17 @@ public class FundingController {
     @GetMapping("/my")
     public ResponseEntity<List<FundingListResponse>> getMyFundings(
             Authentication authentication,
-            @RequestParam(defaultValue = "IN_PROGRESS") FundingStatus status) {
+            @RequestParam(defaultValue = "IN_PROGRESS") FundingStatus status
+
+    ) {
+        if (authentication == null || authentication.getName() == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+
         Long userId = Long.parseLong(authentication.getName());
-        List<FundingListResponse> response = fundingService.getMyFundings(userId, status);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(fundingService.getMyFundings(userId, status));
     }
-    
+
     // 펀딩 중단 POST /api/v1/fundings/{fundingId}/stop
     // body 없이도, 빈 body({})로도, 사유와 함께도 호출 가능
     @PostMapping("/{fundingId}/stop")

--- a/src/main/java/com/likelion/demoday/domain/enums/FundingStatus.java
+++ b/src/main/java/com/likelion/demoday/domain/enums/FundingStatus.java
@@ -1,6 +1,5 @@
 package com.likelion.demoday.domain.enums;
 
-
 public enum FundingStatus {
     // 진행 중인 펀딩
     IN_PROGRESS,
@@ -14,4 +13,3 @@ public enum FundingStatus {
     //마감일 경과로 만료된 펀딩
     ENDED_EXPIRED
 }
-


### PR DESCRIPTION
## 문제
- GET /api/v1/fundings/my 요청 시 403 발생

## 원인
- JwtAuthenticationFilter의 shouldNotFilter에서
  /fundings/my가 게스트 허용으로 스킵됨

## 해결
- /fundings/my를 스킵 대상에서 제외
- SecurityConfig에서 authenticated 보장

closes #1