### PR TITLE
[Fix] AWS S3 업로드, RDS 접속 에러 해결 및 결제 API 연동

### DIFF
--- a/src/main/java/com/likelion/demoday/controller/FundingController.java
+++ b/src/main/java/com/likelion/demoday/controller/FundingController.java
@@ -17,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.http.MediaType;
 import java.io.IOException;
 import java.util.List;
 
@@ -28,7 +29,7 @@ public class FundingController {
     private final FundingService fundingService;
     private final S3Service s3Service;
 
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<BaseResponse<FundingDetailResponse>> createFunding(
             Authentication authentication,
             @Valid @ModelAttribute CreateFundingRequest request) {

--- a/src/main/java/com/likelion/demoday/dto/request/CreateFundingRequest.java
+++ b/src/main/java/com/likelion/demoday/dto/request/CreateFundingRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
@@ -27,9 +28,9 @@ public class CreateFundingRequest {
     
     @NotNull(message = "마감일은 필수입니다.")
     @Future(message = "마감일은 현재 시간 이후여야 합니다.")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private LocalDateTime deadlineAt;
 
-    private MultipartFile image;
     private String description;
 }
 

--- a/src/main/java/com/likelion/demoday/global/aws/S3Service.java
+++ b/src/main/java/com/likelion/demoday/global/aws/S3Service.java
@@ -15,10 +15,10 @@ public class S3Service {
 
     private final S3Template s3Template;
 
-    @Value("${cloud.aws.s3.bucket}")
+    @Value("${spring.cloud.aws.s3.bucket}")
     private String bucket;
 
-    @Value("${cloud.aws.region.static}")
+    @Value("${spring.cloud.aws.region.static}")
     private String region;
 
     public String uploadImage(MultipartFile file) throws IOException {

--- a/src/main/java/com/likelion/demoday/global/config/AwsConfig.java
+++ b/src/main/java/com/likelion/demoday/global/config/AwsConfig.java
@@ -1,0 +1,32 @@
+package com.likelion.demoday.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class AwsConfig {
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)
+                ))
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔧 작업 내용
### 1. AWS S3 설정 수정 (`S3Service`, `AwsConfig`)
- `application.yml`의 들여쓰기 오류로 인한 Property 로딩 실패 해결
- `S3Client` Bean 충돌 문제 해결 (`AwsConfig` 수동 주입 및 Overriding 허용)
- `@Value` 경로 불일치 수정 (`cloud.aws...` -> `spring.cloud.aws...`)

### 2. DB 연결 (`application.yml`)
- RDS 접속 정보(`username`, `password`)가 누락되어 로컬 계정으로 접속 시도하던 문제 해결
- 정상적인 RDS 엔드포인트 연동 확인

### 3. 결제 로직 (`PaymentService`)
- 현재 프론트엔드가 없는 상태에서 테스트하기 위해 `impUid` 검증 로직을 임시로 주석 처리 (테스트 완료 후 해제 예정)
- 스웨거를 통한 가상 결제(`complete`) 및 펀딩 금액 증액 테스트 완료